### PR TITLE
fix: resize disabled nodes

### DIFF
--- a/src/nodes/NodeRenderer.ts
+++ b/src/nodes/NodeRenderer.ts
@@ -216,8 +216,11 @@ export class NodeRenderer {
         }
 
         // resize each node
-        this._nodeGraph.traverse((node) =>
-            node.resize(this.width, this.height)
+        this._nodeGraph.traverse(
+            (node) => node.resize(this.width, this.height),
+            undefined,
+            [],
+            true
         );
 
         // render everything with the new size


### PR DESCRIPTION
onResize was not being called with traverseDisabled set to true.

closes #3 