### PR TITLE
Adds Webgl 2 Multi Sample Render Targets with Webgl 1 render target fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,5 +87,8 @@ typings/
 # DynamoDB Local files
 .dynamodb/
 
+# Jetbrains editor files
+.idea/
+
 dist/
 dev/

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -22,7 +22,7 @@
             TETSUO.Utils.ready(() => {
                 // initialize scene in basic mode
                 // returns a node where objects can be added
-                let { scene, node } = new TETSUO.Scene({
+                let { scene, node } = new TETSUO.Bootstrap({
                     viewportElement: document.getElementById("viewport"),
                     dev: true,
                 }).basic();

--- a/examples/clock.html
+++ b/examples/clock.html
@@ -38,7 +38,7 @@
             // when page is ready
             TETSUO.Utils.ready(() => {
                 // initialize scene
-                let { scene, node } = new TETSUO.Scene({
+                let { scene, node } = new TETSUO.Bootstrap({
                     viewportElement: document.getElementById("viewport"),
                     background: 0x1c1c1c,
                     dev: true,

--- a/examples/depth.html
+++ b/examples/depth.html
@@ -22,7 +22,7 @@
 
         <script>
             TETSUO.Utils.ready(() => {
-                let scene = new TETSUO.Scene({
+                let scene = new TETSUO.Bootstrap({
                     dev: true,
                     autoStart: true,
                 });

--- a/examples/particles.html
+++ b/examples/particles.html
@@ -22,7 +22,7 @@
 
         <script>
             TETSUO.Utils.ready(() => {
-                let scene = new TETSUO.Scene({
+                let scene = new TETSUO.Bootstrap({
                     dev: true,
                     autoStart: true,
                 });

--- a/examples/pixi.html
+++ b/examples/pixi.html
@@ -23,7 +23,10 @@
 
         <script>
             TETSUO.Utils.ready(() => {
-                let scene = new TETSUO.Scene({ dev: true, autoStart: true });
+                let scene = new TETSUO.Bootstrap({
+                    dev: true,
+                    autoStart: true,
+                });
 
                 let pixi = new TETSUO.PIXINode("pixi", scene.renderer);
 

--- a/examples/postprocessing.html
+++ b/examples/postprocessing.html
@@ -20,7 +20,7 @@
         <script>
             TETSUO.Utils.ready(() => {
                 // create a new tetsuo scene
-                let scene = new TETSUO.Scene({ dev: true });
+                let scene = new TETSUO.Bootstrap({ dev: true });
 
                 // create a new three.js scene node
                 // this node renders a three.js scene to a texture

--- a/examples/raymarch.html
+++ b/examples/raymarch.html
@@ -20,7 +20,7 @@
             // when page is ready
             TETSUO.Utils.ready(() => {
                 // initialize the scene
-                const scene = new TETSUO.Scene({
+                const scene = new TETSUO.Bootstrap({
                     viewportElement: document.getElementById("viewport"),
                     dev: true,
                 });

--- a/examples/selector.html
+++ b/examples/selector.html
@@ -22,7 +22,10 @@
 
         <script>
             TETSUO.Utils.ready(() => {
-                let scene = new TETSUO.Scene({ dev: true, autoStart: true });
+                let scene = new TETSUO.Bootstrap({
+                    dev: true,
+                    autoStart: true,
+                });
 
                 let three = new TETSUO.THREENode("three");
 

--- a/src/nodes/NodeRenderer.ts
+++ b/src/nodes/NodeRenderer.ts
@@ -1,4 +1,5 @@
 import * as THREE from "three";
+import { WEBGL } from "three/examples/jsm/WebGL.js";
 import { Viewport } from "../core/Viewport";
 import { NodeGraph } from "./NodeGraph";
 import { Node } from "./Node";
@@ -147,11 +148,25 @@ export class NodeRenderer {
             canvas = this.viewport?.canvas;
         }
 
+        let context: any;
+        if (WEBGL.isWebGL2Available()) {
+            context = canvas?.getContext("webgl2", {
+                antialias: options.antialias,
+            });
+        } else {
+            context = canvas?.getContext("webgl", {
+                antialias: options.antialias,
+                alpha: options.alpha,
+            });
+        }
+        console.log(context);
+
         // initialize renderer
         this.glRenderer = new THREE.WebGLRenderer({
             antialias: options.antialias,
             alpha: options.alpha,
             canvas,
+            context,
         });
 
         // set renderer size depending on size options

--- a/src/nodes/ShaderNode.ts
+++ b/src/nodes/ShaderNode.ts
@@ -2,7 +2,12 @@ import * as THREE from "three";
 import { Node, NodeOptions } from "./Node";
 import { NodeRenderer } from "./NodeRenderer";
 import defaultUniforms from "../shaders/defaultUniforms";
-import { IUniform, WebGLRenderTarget } from "three";
+import {
+    IUniform,
+    WebGLRenderTarget,
+    WebGLMultisampleRenderTarget,
+} from "three";
+import { WEBGL } from "three/examples/jsm/WebGL.js";
 import { UniformNode } from "./UniformNode";
 import { uniqueID } from "../utils/general";
 
@@ -82,7 +87,7 @@ export class ShaderNode extends Node {
     /**
      * Render target for this node
      */
-    private _target: WebGLRenderTarget;
+    private _target: WebGLRenderTarget | WebGLMultisampleRenderTarget;
 
     /**
      * Whether to render this node only when needsUpdate is true
@@ -105,7 +110,12 @@ export class ShaderNode extends Node {
         this.vertexShader = options.vertexShader || defaultVertexShader;
         this.fragmentShader = options.fragmentShader || defaultFragmentShader;
 
-        this._target = new THREE.WebGLRenderTarget(this.width, this.height);
+        this._target = WEBGL.isWebGL2Available()
+            ? new THREE.WebGLMultisampleRenderTarget(this.width, this.height)
+            : new THREE.WebGLRenderTarget(this.width, this.height);
+
+        //TODO: Check if antialising is active on NodeRenderer and change this to 4 or 8
+        //this._target.samples = 8; //default is 4 but to match the built-in AA quality 8 or 16 samples is needed
 
         this.scene = new THREE.Scene();
         this.camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 100);


### PR DESCRIPTION
The goal of this pr is:

- add support if available for webgl2 render targets that allow antialias

Other changes:

- updates examples with TETSUO.Bootstrap
- updates gitignore with .idea folder